### PR TITLE
Bugfix/kaleb coberly/pin flake8 black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ doc =
 qc =
     bandit>=1.8.6
     black>=25.1.0
-    black[jupyter]>=25.1.0
     flake8>=7.3.0
     flake8-annotations>=3.1.1
     flake8-bandit>=4.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stormwater_monitoring_datasheet_extraction
-version = 0.0.10
+version = 0.0.11
 description = Extracts stormwater monitoring field observations from datasheet PDFs.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,12 +46,12 @@ doc =
 
 qc =
     bandit>=1.8.6
-    black>=25.1.0,<25.9.0
+    black>=25.1.0
     black[jupyter]>=25.1.0
     flake8>=7.3.0
     flake8-annotations>=3.1.1
     flake8-bandit>=4.1.1
-    flake8-black>=0.3.6
+    flake8-black>=0.4.0
     flake8-bugbear>=24.12.12
     flake8-docstrings>=1.7.0
     flake8-isort>=6.1.2


### PR DESCRIPTION
Pins to `flake8-black` release that pins `black` to avoid breaking release.
Also removes unnecessary `flake8-black[jupyter]`.