### PR TITLE
Bugfix/kaleb coberly/pandera typing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ packages=find:
 install_requires =
     click>=8.2.1,<9.0.0
     comb_utils>=0.1.0,<1.0.0
+    numpy<2.4.0
     pandas>=2.3.2,<3.0.0
     pandera[extensions]>=0.26.1,<0.27.0
     typeguard>=4.4.4,<5.0.0


### PR DESCRIPTION
Pins to `numpy<2.4.0`, to avoid Pandera typechecking errors. (NumPy release was mainly for Python 3.14 free threading, which we're not supporting yet. And, the https://scientific-python.org/specs/spec-0000/#support-window is squarely in NumPy 2.3.0 anyway.)