### PR TITLE
nltk develop

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stormwater_monitoring_datasheet_extraction
-version = 0.0.27
+version = 0.0.28
 description = Extracts stormwater monitoring field observations from datasheet PDFs.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ packages=find:
 install_requires =
     click>=8.2.1,<9.0.0
     comb_utils>=0.1.0,<1.0.0
+    # Until nltk 3.9.3 is released: https://github.com/nltk/nltk/pull/3503
+    nltk @ git+https://github.com/nltk/nltk.git@develop
     pandera[extensions]>=0.29.0,<0.30.0
     typeguard>=4.4.4,<5.0.0
 


### PR DESCRIPTION
Partially addresses https://github.com/crickets-and-comb/shared/issues/152
Pins to `nltk@develop` until 3.9.3 released to address CVE-2025-14009.
Updates `shared` Git submodule to ignore for now.